### PR TITLE
Credential Scope

### DIFF
--- a/botocore/args.py
+++ b/botocore/args.py
@@ -153,8 +153,9 @@ class ClientArgsCreator:
             protocol, parameter_validation
         )
         response_parser = botocore.parsers.create_parser(protocol)
+        uses_builtin_data = endpoint_bridge.resolver_uses_builtin_data()
         builtin_resolver = self._construct_builtin_resolver(
-            credentials, new_config
+            credentials, new_config, uses_builtin_data
         )
         ruleset_resolver = self._build_endpoint_resolver(
             endpoints_ruleset_data,
@@ -620,12 +621,15 @@ class ClientArgsCreator:
         else:
             return val.lower() == 'true'
 
-    def _construct_builtin_resolver(self, credentials, client_config):
+    def _construct_builtin_resolver(
+        self, credentials, client_config, uses_builtin_data
+    ):
         credential_builtin_resolver = CredentialBuiltinResolver(
-            credentials, client_config.account_id_endpoint_mode
+            credentials,
+            client_config.account_id_endpoint_mode,
         )
         resolver_map = {'credentials': credential_builtin_resolver}
-        return EndpointBuiltinResolver(resolver_map)
+        return EndpointBuiltinResolver(resolver_map, uses_builtin_data)
 
     def _build_endpoint_resolver(
         self,
@@ -778,6 +782,9 @@ class ClientArgsCreator:
             # account ID is calculated later if account based routing is
             # enabled and configured for the service
             EPRBuiltins.AWS_ACCOUNT_ID: None,
+            # credential scope is calculated later if configured on the
+            # credentials
+            EPRBuiltins.AWS_CREDENTIAL_SCOPE: None,
         }
 
     def _compute_user_agent_appid_config(self, config_kwargs):

--- a/botocore/client.py
+++ b/botocore/client.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import logging
+import warnings
 
 from botocore import waiter, xform_name
 from botocore.args import ClientArgsCreator
@@ -1091,12 +1092,33 @@ class BaseClient:
                 request_context['auth_type'] = auth_type
                 if 'region' in signing_context and ignore_signing_region:
                     del signing_context['region']
+                self._maybe_warn_signing_region_mismatch(signing_context)
                 if 'signing' in request_context:
                     request_context['signing'].update(signing_context)
                 else:
                     request_context['signing'] = signing_context
 
         return endpoint_url, additional_headers
+
+    def _maybe_warn_signing_region_mismatch(self, signing_context):
+        legacy_signing_region = self._request_signer.region_name
+        signing_region = signing_context.get('region')
+        if (
+            signing_region is not None
+            and legacy_signing_region != signing_region
+            and not self._ruleset_resolver.uses_builtin_data_path
+            and self._ruleset_resolver.credential_scope_set
+        ):
+            warnings.warn(
+                "Detected an endpoint resolved from a custom endpoints.json"
+                "file and credentials scoped to a single region:  "
+                f"'{signing_region}'. The signing region this file has "
+                "resolved does not match the signing region of the client. "
+                "This may cause issues with request signing.\n"
+                f"legacy signing region: '{legacy_signing_region}'\n"
+                f"current signing region: '{signing_region}'\n "
+                f"Using '{signing_region}' to sign the request."
+            )
 
     def get_paginator(self, operation_name):
         """Create a paginator for an operation.

--- a/botocore/session.py
+++ b/botocore/session.py
@@ -480,7 +480,7 @@ class Session:
         self._client_config = client_config
 
     def set_credentials(
-        self, access_key, secret_key, token=None, account_id=None
+        self, access_key, secret_key, token=None, account_id=None, scope=None
     ):
         """
         Manually create credentials for this session.  If you would
@@ -500,9 +500,12 @@ class Session:
 
         :type account_id: str
         :param account_id: The account ID for the credentials.
+
+        :type scope: str
+        :param scope: The scope for the credentials.
         """
         self._credentials = botocore.credentials.Credentials(
-            access_key, secret_key, token, account_id=account_id
+            access_key, secret_key, token, account_id=account_id, scope=scope
         )
 
     def get_credentials(self):
@@ -847,6 +850,7 @@ class Session:
         aws_session_token=None,
         config=None,
         aws_account_id=None,
+        aws_credential_scope=None,
     ):
         """Create a botocore client.
 
@@ -919,6 +923,11 @@ class Session:
         :type aws_account_id: string
         :param aws_account_id: The AWS account ID to use when creating the client.
             Same semantics as aws_access_key_id above.
+
+        :type aws_credential_scope: string
+        :param aws_credential_scope: The AWS credential scope to use when creating
+            creating the client. Same semantics as aws_access_key_id above. Must be
+            equal to region_name.
         """
         default_client_config = self.get_default_client_config()
         # If a config is provided and a default config is set, then
@@ -955,6 +964,7 @@ class Session:
                 secret_key=aws_secret_access_key,
                 token=aws_session_token,
                 account_id=aws_account_id,
+                scope=aws_credential_scope,
             )
         elif self._missing_cred_vars(aws_access_key_id, aws_secret_access_key):
             raise PartialCredentialsError(

--- a/tests/functional/test_endpoint_rulesets.py
+++ b/tests/functional/test_endpoint_rulesets.py
@@ -14,6 +14,7 @@
 import json
 from functools import lru_cache
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -305,3 +306,28 @@ def test_end_to_end_test_cases_yielding_errors(
             except (ClientError, ResponseParserError):
                 pass
         assert len(http_stubber.requests) == 0
+
+
+@mock.patch('botocore.signers.RequestSigner.region_name', 'us-east-1')
+@mock.patch(
+    'botocore.regions.EndpointRulesetResolver.auth_schemes_to_signing_ctx',
+    return_value=('v4', {'region': 'us-west-2'}),
+)
+@mock.patch(
+    'botocore.regions.EndpointRulesetResolver.uses_builtin_data_path', False
+)
+@mock.patch(
+    'botocore.regions.EndpointRulesetResolver.credential_scope_set', True
+)
+def test_signing_region_mismatch_warns(auth_schemes_mock, patched_session):
+    patched_session.set_credentials(
+        access_key='foo', secret_key='bar', token='baz', scope='us-west-2'
+    )
+    client = patched_session.create_client('iam', region_name='us-west-2')
+    body = b'<ListRolesResponse><ListRolesResult></ListRolesResult></ListRolesResponse>'
+    with ClientHTTPStubber(client) as http_stubber:
+        http_stubber.add_response(status=200, body=body)
+        with pytest.warns(
+            UserWarning, match='does not match the signing region'
+        ):
+            client.list_roles()

--- a/tests/integration/test_credentials.py
+++ b/tests/integration/test_credentials.py
@@ -76,6 +76,7 @@ class TestCredentialPrecedence(BaseEnvVar):
             secret_key='code-secret',
             token=mock.ANY,
             account_id=mock.ANY,
+            scope=mock.ANY,
         )
 
     def test_profile_env_vs_code(self):
@@ -104,6 +105,7 @@ class TestCredentialPrecedence(BaseEnvVar):
             secret_key='code-secret',
             token=mock.ANY,
             account_id=mock.ANY,
+            scope=mock.ANY,
         )
 
     def test_access_secret_env_vs_profile_code(self):

--- a/tests/unit/data/endpoints/valid-rules/aws-credential-scope.json
+++ b/tests/unit/data/endpoints/valid-rules/aws-credential-scope.json
@@ -1,0 +1,95 @@
+{
+  "parameters": {
+    "Region": {
+      "type": "string",
+      "builtIn": "AWS::Region",
+      "documentation": "The region to dispatch this request, eg. `us-east-1`."
+    },
+    "CredentialScope": {
+      "type": "string",
+      "builtIn": "AWS::Auth::CredentialScope",
+      "documentation": "The credential scope to dispatch this request, eg. `us-east-1`."
+    }
+  },
+  "rules": [
+    {
+      "documentation": "Template the credential scope into the URI when it is set",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "CredentialScope"
+            }
+          ]
+        },
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Region"
+            }
+          ]
+        },
+        {
+          "fn": "stringEquals",
+          "argv": [
+            {
+              "ref": "Region"
+            },
+            {
+              "ref": "CredentialScope"
+            }
+          ]
+        }
+      ],
+      "endpoint": {
+        "url": "https://{Region}.amazonaws.com",
+        "properties": {
+          "authSchemes": [
+            {
+              "name": "sigv4",
+              "signingName": "serviceName",
+              "signingRegion": "{Region}"
+            }
+          ]
+        }
+      },
+      "type": "endpoint"
+    },
+    {
+      "documentation": "Fallback when credential scope isn't set",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Region"
+            }
+          ]
+        }
+      ],
+      "endpoint": {
+        "url": "https://amazonaws.com",
+        "properties": {
+          "authSchemes": [
+            {
+              "name": "sigv4",
+              "signingName": "serviceName",
+              "signingRegion": "{Region}"
+            }
+          ]
+        }
+      },
+      "type": "endpoint"
+    },
+    
+    {
+      "documentation": "fallback when region is unset",
+      "conditions": [],
+      "error": "Region must be set to resolve a valid endpoint",
+      "type": "error"
+    }
+  ],
+  "version": "1.3"
+}

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -558,6 +558,7 @@ class TestCreateClient(BaseSessionTest):
             aws_secret_access_key='bar',
             aws_session_token='baz',
             aws_account_id='123456789012',
+            aws_credential_scope='us-west-2',
         )
         call_args = client_creator.return_value.create_client.call_args[1]
         credentials = call_args['credentials']
@@ -565,6 +566,7 @@ class TestCreateClient(BaseSessionTest):
         self.assertEqual(credentials.secret_key, 'bar')
         self.assertEqual(credentials.token, 'baz')
         self.assertEqual(credentials.account_id, '123456789012')
+        self.assertEqual(credentials.scope, 'us-west-2')
 
     def test_cred_provider_not_called_on_unsigned_client(self):
         cred_provider = mock.Mock()


### PR DESCRIPTION
This PR adds a `scope` to credentials that is used for endpoint resolution through the `AWS::AuthCredentialScope` builtin parameter. Similar to account ID, it is treated as completely optional and only set on credential fetchers if the value is present. A couple of properties are added to the endpoint builtin resolver and piped through to the ruleset resolver in order to raise a configuration warning for customers that still rely on legacy behavior.

The base branch is https://github.com/dlm6693/botocore/tree/account-id-endpoints since this PR is largely built on top of that branch and both will be merged at the same time. Once this is approved, account ID will be merged, this branch will be rebased with those changes and the base branch will be updated to https://github.com/boto/botocore/tree/develop/